### PR TITLE
Cooldown spell effects and aura update

### DIFF
--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -433,6 +433,8 @@ public:
     void EffectRechargeManaGem(SpellEffIndex effIndex);
     void EffectCreateAreaTrigger(SpellEffIndex effIndex);
     void EffectJumpCharge(SpellEffIndex effIndex);
+    void EffectModifyCurrentSpellCooldown(SpellEffIndex effIndex);
+    void EffectRemoveCurrentSpellCooldown(SpellEffIndex effIndex);
 
     typedef std::set<Aura*> UsedSpellMods;
 

--- a/src/server/shared/SharedDefines.h
+++ b/src/server/shared/SharedDefines.h
@@ -1074,6 +1074,8 @@ enum SpellEffects
     SPELL_EFFECT_LEARN_TRANSMOG_SET                 = 165, 
     SPELL_EFFECT_CREATE_AREATRIGGER                 = 166,
     SPELL_EFFECT_JUMP_CHARGE                        = 167,
+    SPELL_EFFECT_MODIFY_CURRENT_SPELL_COOLDOWN      = 168,
+    SPELL_EFFECT_REMOVE_CURRENT_SPELL_COOLDOWN      = 169,
     TOTAL_SPELL_EFFECTS                            
 };
 


### PR DESCRIPTION
Spell effects allowing to reduce/remove cooldowns from masked spells without creating spell scripts. Small update to cooldown recovery aura.