### PR TITLE
Fix compilation by using type bool instead of boolean

### DIFF
--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -1589,7 +1589,7 @@ public:
         return _forgeMythicKeys;
     }
 
-    boolean AffixExistsAndMatchesTier(uint32 affix, uint8 tier) {
+    bool AffixExistsAndMatchesTier(uint32 affix, uint8 tier) {
         auto find = _forgeAffixes.find(affix);
         if (find != _forgeAffixes.end())
             return find->second->tier == tier;


### PR DESCRIPTION
This might be to windows supporting the `boolean` keyword for c++ but from the code source standpoint and alternative compilers using `bool` is the right way.
