### PR TITLE
Conditionally release if branch is master

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -51,6 +51,7 @@ jobs:
           Compress-Archive -Path ./data/sql/custom -Destination ./env/dist/data-sql.zip
 
       - uses: "marvinpinto/action-automatic-releases@latest"
+        if: github.ref == 'refs/heads/master'
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         with:


### PR DESCRIPTION
If run on non master branch we would like to avoid triggering a release. This will avoid generating releases (or fail currently) on each PR pushed to this repo.
